### PR TITLE
feat: set tab min-width to 100px

### DIFF
--- a/src/components/Tab/style.module.css
+++ b/src/components/Tab/style.module.css
@@ -2,6 +2,7 @@
   align-items: center;
   background-color: transparent;
   border-radius: 6px;
+  min-width: 100px;
   max-width: 300px;
   cursor: pointer;
   display: flex;

--- a/src/components/Tab/style.module.css
+++ b/src/components/Tab/style.module.css
@@ -2,7 +2,7 @@
   align-items: center;
   background-color: transparent;
   border-radius: 6px;
-  min-width: 100px;
+  min-width: 70px;
   max-width: 300px;
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
This pull request makes a small style adjustment to the `Tab` component by setting a minimum width to ensure consistent sizing.

- Added a `min-width: 100px;` rule to `src/components/Tab/style.module.css` to improve the appearance and usability of tabs.