### PR TITLE
feat: make tabs draggable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+package-lock.json
 
 node_modules
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
-package-lock.json
 
 node_modules
 dist

--- a/package.json
+++ b/package.json
@@ -19,9 +19,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/react": "0.3.2",
+    "@dnd-kit/helpers": "0.3.2",
     "@excalidraw/excalidraw": "0.18.0",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.1.13",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dnd-kit/react": "0.3.2",
+    "@dnd-kit/abstract": "^0.3.2",
+    "@dnd-kit/dom": "^0.3.2",
     "@dnd-kit/helpers": "0.3.2",
+    "@dnd-kit/react": "0.3.2",
     "@excalidraw/excalidraw": "0.18.0",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.1.13",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@excalidraw/excalidraw": "0.18.0",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.1)
       '@excalidraw/excalidraw':
         specifier: 0.18.0
         version: 0.18.0(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -206,6 +215,28 @@ packages:
 
   '@braintree/sanitize-url@6.0.2':
     resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
@@ -811,56 +842,67 @@ packages:
     resolution: {integrity: sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.2':
     resolution: {integrity: sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.2':
     resolution: {integrity: sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.2':
     resolution: {integrity: sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.2':
     resolution: {integrity: sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.2':
     resolution: {integrity: sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.2':
     resolution: {integrity: sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.2':
     resolution: {integrity: sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.2':
     resolution: {integrity: sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.2':
     resolution: {integrity: sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.2':
     resolution: {integrity: sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.2':
     resolution: {integrity: sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==}
@@ -928,24 +970,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
     resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
     resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.13':
     resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.13':
     resolution: {integrity: sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==}
@@ -2080,24 +2126,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -3003,6 +3053,31 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@braintree/sanitize-url@6.0.2': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.25.10':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/abstract':
+        specifier: ^0.3.2
+        version: 0.3.2
+      '@dnd-kit/dom':
+        specifier: ^0.3.2
+        version: 0.3.2
       '@dnd-kit/helpers':
         specifier: 0.3.2
         version: 0.3.2
@@ -844,67 +850,56 @@ packages:
     resolution: {integrity: sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.2':
     resolution: {integrity: sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.2':
     resolution: {integrity: sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.2':
     resolution: {integrity: sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.2':
     resolution: {integrity: sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.2':
     resolution: {integrity: sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.2':
     resolution: {integrity: sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.2':
     resolution: {integrity: sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.2':
     resolution: {integrity: sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.2':
     resolution: {integrity: sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.2':
     resolution: {integrity: sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.2':
     resolution: {integrity: sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==}
@@ -972,28 +967,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
     resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
     resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.13':
     resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.13':
     resolution: {integrity: sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==}
@@ -2128,28 +2119,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,12 @@ importers:
 
   .:
     dependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.1.1)
+      '@dnd-kit/helpers':
+        specifier: 0.3.2
+        version: 0.3.2
+      '@dnd-kit/react':
+        specifier: 0.3.2
+        version: 0.3.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@excalidraw/excalidraw':
         specifier: 0.18.0
         version: 0.18.0(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -216,27 +213,29 @@ packages:
   '@braintree/sanitize-url@6.0.2':
     resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
 
-  '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
-    peerDependencies:
-      react: '>=16.8.0'
+  '@dnd-kit/abstract@0.3.2':
+    resolution: {integrity: sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==}
 
-  '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+  '@dnd-kit/collision@0.3.2':
+    resolution: {integrity: sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==}
 
-  '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.3.0
-      react: '>=16.8.0'
+  '@dnd-kit/dom@0.3.2':
+    resolution: {integrity: sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==}
 
-  '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+  '@dnd-kit/geometry@0.3.2':
+    resolution: {integrity: sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==}
+
+  '@dnd-kit/helpers@0.3.2':
+    resolution: {integrity: sha512-pj7pCE6BiysNetpPnzb3BJOrcKiqueUr1LFg6wYoi2fIFYpz66n2Ojd7HTwfwkpv0oyC3QlvA6Dk8cOmi6VavA==}
+
+  '@dnd-kit/react@0.3.2':
+    resolution: {integrity: sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.3.2':
+    resolution: {integrity: sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==}
 
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
@@ -522,6 +521,9 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@preact/signals-core@1.14.0':
+    resolution: {integrity: sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ==}
 
   '@radix-ui/primitive@1.0.0':
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
@@ -3054,29 +3056,48 @@ snapshots:
 
   '@braintree/sanitize-url@6.0.2': {}
 
-  '@dnd-kit/accessibility@3.1.1(react@19.1.1)':
+  '@dnd-kit/abstract@0.3.2':
     dependencies:
-      react: 19.1.1
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
       tslib: 2.8.1
 
-  '@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@dnd-kit/collision@0.3.2':
     dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@19.1.1)
-      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/collision': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.3.2':
+    dependencies:
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/helpers@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.3.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/dom': 0.3.2
+      '@dnd-kit/state': 0.3.2
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       tslib: 2.8.1
 
-  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+  '@dnd-kit/state@0.3.2':
     dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
-      react: 19.1.1
-      tslib: 2.8.1
-
-  '@dnd-kit/utilities@3.2.2(react@19.1.1)':
-    dependencies:
-      react: 19.1.1
+      '@preact/signals-core': 1.14.0
       tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.25.10':
@@ -3325,6 +3346,8 @@ snapshots:
       fastq: 1.19.1
 
   '@pkgr/core@0.2.9': {}
+
+  '@preact/signals-core@1.14.0': {}
 
   '@radix-ui/primitive@1.0.0':
     dependencies:

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -1,3 +1,5 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -9,37 +11,36 @@ import styles from './style.module.css';
 
 interface TabProps {
   tab: ITab;
-  draggable?: boolean;
-  isDragging?: boolean;
-  isDragOver?: boolean;
-  onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
-  onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
-  onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
-  onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
 interface FormData {
   title: string;
 }
 
-const Tab = ({
-  tab,
-  draggable = false,
-  isDragging = false,
-  isDragOver = false,
-  onDragStart,
-  onDragOver,
-  onDrop,
-  onDragEnd,
-}: TabProps) => {
+const Tab = ({ tab }: TabProps) => {
   const { currentTabId, setCurrentTabId, updateTab, deleteTab } = useAppStore();
   const [isEditing, setIsEditing] = useState(false);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: tab.id,
+    disabled: isEditing,
+  });
 
   const { register, handleSubmit, reset } = useForm<FormData>({
     defaultValues: { title: tab.title },
   });
 
   const isActive = currentTabId === tab.id;
+  const tabStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -76,16 +77,14 @@ const Tab = ({
 
   return (
     <div
+      ref={setNodeRef}
+      style={tabStyle}
       className={clsx(styles.tab, {
         [styles.active]: isActive,
         [styles.dragging]: isDragging,
-        [styles.dragOver]: isDragOver,
       })}
-      draggable={draggable}
-      onDragStart={onDragStart}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      onDragEnd={onDragEnd}
+      {...attributes}
+      {...listeners}
       onClick={() => setCurrentTabId(tab.id)}
     >
       {!isEditing && (

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -20,6 +20,11 @@ interface FormData {
 const Tab = ({ tab, index }: TabProps) => {
   const { currentTabId, setCurrentTabId, updateTab, deleteTab } = useAppStore();
   const [isEditing, setIsEditing] = useState(false);
+
+  const { register, handleSubmit, reset } = useForm<FormData>({
+    defaultValues: { title: tab.title },
+  });
+
   const { ref, isDragging } = useSortable({
     id: tab.id,
     index,
@@ -27,11 +32,8 @@ const Tab = ({ tab, index }: TabProps) => {
     disabled: isEditing,
   });
 
-  const { register, handleSubmit, reset } = useForm<FormData>({
-    defaultValues: { title: tab.title },
-  });
-
   const isActive = currentTabId === tab.id;
+
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
 

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -9,13 +9,29 @@ import styles from './style.module.css';
 
 interface TabProps {
   tab: ITab;
+  draggable?: boolean;
+  isDragging?: boolean;
+  isDragOver?: boolean;
+  onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
 interface FormData {
   title: string;
 }
 
-const Tab = ({ tab }: TabProps) => {
+const Tab = ({
+  tab,
+  draggable = false,
+  isDragging = false,
+  isDragOver = false,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: TabProps) => {
   const { currentTabId, setCurrentTabId, updateTab, deleteTab } = useAppStore();
   const [isEditing, setIsEditing] = useState(false);
 
@@ -60,7 +76,16 @@ const Tab = ({ tab }: TabProps) => {
 
   return (
     <div
-      className={clsx(styles.tab, { [styles.active]: isActive })}
+      className={clsx(styles.tab, {
+        [styles.active]: isActive,
+        [styles.dragging]: isDragging,
+        [styles.dragOver]: isDragOver,
+      })}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
       onClick={() => setCurrentTabId(tab.id)}
     >
       {!isEditing && (

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -1,5 +1,4 @@
-import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
+import { useSortable } from '@dnd-kit/react/sortable';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -11,24 +10,20 @@ import styles from './style.module.css';
 
 interface TabProps {
   tab: ITab;
+  index: number;
 }
 
 interface FormData {
   title: string;
 }
 
-const Tab = ({ tab }: TabProps) => {
+const Tab = ({ tab, index }: TabProps) => {
   const { currentTabId, setCurrentTabId, updateTab, deleteTab } = useAppStore();
   const [isEditing, setIsEditing] = useState(false);
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({
+  const { ref, isDragging } = useSortable({
     id: tab.id,
+    index,
+    group: 'tabs',
     disabled: isEditing,
   });
 
@@ -37,11 +32,6 @@ const Tab = ({ tab }: TabProps) => {
   });
 
   const isActive = currentTabId === tab.id;
-  const tabStyle = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
-
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
 
@@ -77,14 +67,11 @@ const Tab = ({ tab }: TabProps) => {
 
   return (
     <div
-      ref={setNodeRef}
-      style={tabStyle}
+      ref={ref}
       className={clsx(styles.tab, {
         [styles.active]: isActive,
         [styles.dragging]: isDragging,
       })}
-      {...attributes}
-      {...listeners}
       onClick={() => setCurrentTabId(tab.id)}
     >
       {!isEditing && (

--- a/src/components/Tab/style.module.css
+++ b/src/components/Tab/style.module.css
@@ -16,7 +16,6 @@
 
   &:hover {
     background-color: #f1f0ff; /*--button-hover-bg*/
-    cursor: move;
   }
 
   &.active {
@@ -25,11 +24,7 @@
 
   &.dragging {
     opacity: 0.5;
-  }
-
-  &.dragOver {
-    outline: 2px solid #6965db;
-    outline-offset: -2px;
+    z-index: 1;
   }
 
   & button {

--- a/src/components/Tab/style.module.css
+++ b/src/components/Tab/style.module.css
@@ -4,7 +4,7 @@
   border-radius: 6px;
   min-width: 80px;
   max-width: 300px;
-  cursor: pointer;
+  cursor: grab;
   display: flex;
   font-weight: 400;
   gap: 10px;

--- a/src/components/Tab/style.module.css
+++ b/src/components/Tab/style.module.css
@@ -2,7 +2,7 @@
   align-items: center;
   background-color: transparent;
   border-radius: 6px;
-  min-width: 70px;
+  min-width: 80px;
   max-width: 300px;
   cursor: pointer;
   display: flex;

--- a/src/components/Tab/style.module.css
+++ b/src/components/Tab/style.module.css
@@ -16,10 +16,20 @@
 
   &:hover {
     background-color: #f1f0ff; /*--button-hover-bg*/
+    cursor: move;
   }
 
   &.active {
     background-color: #e0dfff; /*--color-surface-primary-container*/
+  }
+
+  &.dragging {
+    opacity: 0.5;
+  }
+
+  &.dragOver {
+    outline: 2px solid #6965db;
+    outline-offset: -2px;
   }
 
   & button {

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { useAppStore } from '../../store';
 import { PlusIcon } from '../icons';
 import ImportModal from '../ImportButton';
@@ -5,19 +7,61 @@ import Tab from '../Tab';
 import style from './style.module.css';
 
 const TabBar = () => {
-  const { tabs, setCurrentTabId, createTab } = useAppStore();
+  const { tabs, setCurrentTabId, createTab, moveTab } = useAppStore();
+  const [draggedTabId, setDraggedTabId] = useState<number | null>(null);
+  const [dragOverTabId, setDragOverTabId] = useState<number | null>(null);
 
   const handleCreateTabBtnClick = () => {
     const newTabId = createTab();
     setCurrentTabId(newTabId);
   };
 
+  const handleDragStart =
+    (tabId: number) => (e: React.DragEvent<HTMLDivElement>) => {
+      setDraggedTabId(tabId);
+      e.dataTransfer.effectAllowed = 'move';
+    };
+
+  const handleDragOver =
+    (tabId: number) => (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      if (dragOverTabId !== tabId) {
+        setDragOverTabId(tabId);
+      }
+    };
+
+  const handleDrop =
+    (targetTabId: number) => (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      if (draggedTabId !== null && draggedTabId !== targetTabId) {
+        moveTab(draggedTabId, targetTabId);
+      }
+      setDraggedTabId(null);
+      setDragOverTabId(null);
+    };
+
+  const handleDragEnd = () => {
+    setDraggedTabId(null);
+    setDragOverTabId(null);
+  };
+
   return (
     <>
       <div className={style.container}>
         <div className={style.tabBar}>
-          {tabs.map((tab, index) => (
-            <Tab key={index} tab={tab} />
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.id}
+              tab={tab}
+              draggable
+              isDragging={draggedTabId === tab.id}
+              isDragOver={dragOverTabId === tab.id}
+              onDragStart={handleDragStart(tab.id)}
+              onDragOver={handleDragOver(tab.id)}
+              onDrop={handleDrop(tab.id)}
+              onDragEnd={handleDragEnd}
+            />
           ))}
         </div>
         <button

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -1,5 +1,6 @@
 import { RestrictToHorizontalAxis } from '@dnd-kit/abstract/modifiers';
 import { RestrictToElement } from '@dnd-kit/dom/modifiers';
+import { move } from '@dnd-kit/helpers';
 import { type DragDropEventHandlers, DragDropProvider } from '@dnd-kit/react';
 import { useRef } from 'react';
 
@@ -10,7 +11,7 @@ import Tab from '../Tab';
 import style from './style.module.css';
 
 const TabBar = () => {
-  const { tabs, setCurrentTabId, createTab, moveTab } = useAppStore();
+  const { tabs, setCurrentTabId, createTab, setTabs } = useAppStore();
   const tabBarRef = useRef<HTMLDivElement>(null);
 
   const handleCreateTabBtnClick = () => {
@@ -18,17 +19,13 @@ const TabBar = () => {
     setCurrentTabId(newTabId);
   };
 
-  const handleDragEnd: NonNullable<DragDropEventHandlers['onDragEnd']> = ({
-    canceled,
-    operation,
-  }) => {
-    if (canceled) return;
-
-    const sourceId = operation.source?.id;
-    const targetId = operation.target?.id;
-
-    if (sourceId == null || targetId == null || sourceId === targetId) return;
-    moveTab(Number(sourceId), Number(targetId));
+  const handleDragEnd: NonNullable<DragDropEventHandlers['onDragEnd']> = (
+    event,
+  ) => {
+    if (event.canceled) return;
+    const movedTabs = move(tabs, event);
+    if (movedTabs === tabs) return;
+    setTabs(movedTabs);
   };
 
   return (

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -1,4 +1,15 @@
-import { useState } from 'react';
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  horizontalListSortingStrategy,
+  SortableContext,
+} from '@dnd-kit/sortable';
 
 import { useAppStore } from '../../store';
 import { PlusIcon } from '../icons';
@@ -8,62 +19,43 @@ import style from './style.module.css';
 
 const TabBar = () => {
   const { tabs, setCurrentTabId, createTab, moveTab } = useAppStore();
-  const [draggedTabId, setDraggedTabId] = useState<number | null>(null);
-  const [dragOverTabId, setDragOverTabId] = useState<number | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+  );
 
   const handleCreateTabBtnClick = () => {
     const newTabId = createTab();
     setCurrentTabId(newTabId);
   };
 
-  const handleDragStart =
-    (tabId: number) => (e: React.DragEvent<HTMLDivElement>) => {
-      setDraggedTabId(tabId);
-      e.dataTransfer.effectAllowed = 'move';
-    };
-
-  const handleDragOver =
-    (tabId: number) => (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
-      if (dragOverTabId !== tabId) {
-        setDragOverTabId(tabId);
-      }
-    };
-
-  const handleDrop =
-    (targetTabId: number) => (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      if (draggedTabId !== null && draggedTabId !== targetTabId) {
-        moveTab(draggedTabId, targetTabId);
-      }
-      setDraggedTabId(null);
-      setDragOverTabId(null);
-    };
-
-  const handleDragEnd = () => {
-    setDraggedTabId(null);
-    setDragOverTabId(null);
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    moveTab(Number(active.id), Number(over.id));
   };
 
   return (
     <>
       <div className={style.container}>
-        <div className={style.tabBar}>
-          {tabs.map((tab) => (
-            <Tab
-              key={tab.id}
-              tab={tab}
-              draggable
-              isDragging={draggedTabId === tab.id}
-              isDragOver={dragOverTabId === tab.id}
-              onDragStart={handleDragStart(tab.id)}
-              onDragOver={handleDragOver(tab.id)}
-              onDrop={handleDrop(tab.id)}
-              onDragEnd={handleDragEnd}
-            />
-          ))}
-        </div>
+        <DndContext
+          collisionDetection={closestCenter}
+          sensors={sensors}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={tabs.map((tab) => tab.id)}
+            strategy={horizontalListSortingStrategy}
+          >
+            <div className={style.tabBar}>
+              {tabs.map((tab) => (
+                <Tab key={tab.id} tab={tab} />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
         <button
           className={style.createTabButton}
           onClick={handleCreateTabBtnClick}

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -1,4 +1,7 @@
-import { DragDropProvider, type DragDropEventHandlers } from '@dnd-kit/react';
+import { RestrictToHorizontalAxis } from '@dnd-kit/abstract/modifiers';
+import { RestrictToElement } from '@dnd-kit/dom/modifiers';
+import { type DragDropEventHandlers, DragDropProvider } from '@dnd-kit/react';
+import { useRef } from 'react';
 
 import { useAppStore } from '../../store';
 import { PlusIcon } from '../icons';
@@ -8,6 +11,7 @@ import style from './style.module.css';
 
 const TabBar = () => {
   const { tabs, setCurrentTabId, createTab, moveTab } = useAppStore();
+  const tabBarRef = useRef<HTMLDivElement>(null);
 
   const handleCreateTabBtnClick = () => {
     const newTabId = createTab();
@@ -30,8 +34,14 @@ const TabBar = () => {
   return (
     <>
       <div className={style.container}>
-        <DragDropProvider onDragEnd={handleDragEnd}>
-          <div className={style.tabBar}>
+        <DragDropProvider
+          onDragEnd={handleDragEnd}
+          modifiers={[
+            RestrictToHorizontalAxis,
+            RestrictToElement.configure({ element: tabBarRef.current }),
+          ]}
+        >
+          <div className={style.tabBar} ref={tabBarRef}>
             {tabs.map((tab, index) => (
               <Tab key={tab.id} tab={tab} index={index} />
             ))}

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -1,15 +1,4 @@
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core';
-import {
-  horizontalListSortingStrategy,
-  SortableContext,
-} from '@dnd-kit/sortable';
+import { DragDropProvider, type DragDropEventHandlers } from '@dnd-kit/react';
 
 import { useAppStore } from '../../store';
 import { PlusIcon } from '../icons';
@@ -19,43 +8,35 @@ import style from './style.module.css';
 
 const TabBar = () => {
   const { tabs, setCurrentTabId, createTab, moveTab } = useAppStore();
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8,
-      },
-    }),
-  );
 
   const handleCreateTabBtnClick = () => {
     const newTabId = createTab();
     setCurrentTabId(newTabId);
   };
 
-  const handleDragEnd = ({ active, over }: DragEndEvent) => {
-    if (!over || active.id === over.id) return;
-    moveTab(Number(active.id), Number(over.id));
+  const handleDragEnd: NonNullable<DragDropEventHandlers['onDragEnd']> = ({
+    canceled,
+    operation,
+  }) => {
+    if (canceled) return;
+
+    const sourceId = operation.source?.id;
+    const targetId = operation.target?.id;
+
+    if (sourceId == null || targetId == null || sourceId === targetId) return;
+    moveTab(Number(sourceId), Number(targetId));
   };
 
   return (
     <>
       <div className={style.container}>
-        <DndContext
-          collisionDetection={closestCenter}
-          sensors={sensors}
-          onDragEnd={handleDragEnd}
-        >
-          <SortableContext
-            items={tabs.map((tab) => tab.id)}
-            strategy={horizontalListSortingStrategy}
-          >
-            <div className={style.tabBar}>
-              {tabs.map((tab) => (
-                <Tab key={tab.id} tab={tab} />
-              ))}
-            </div>
-          </SortableContext>
-        </DndContext>
+        <DragDropProvider onDragEnd={handleDragEnd}>
+          <div className={style.tabBar}>
+            {tabs.map((tab, index) => (
+              <Tab key={tab.id} tab={tab} index={index} />
+            ))}
+          </div>
+        </DragDropProvider>
         <button
           className={style.createTabButton}
           onClick={handleCreateTabBtnClick}

--- a/src/components/TabBar/style.module.css
+++ b/src/components/TabBar/style.module.css
@@ -10,6 +10,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  margin-right: 5px;
 }
 
 .createTabButton {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -8,6 +8,7 @@ interface AppStoreState extends AppData {
   createTab: () => number;
   updateTab: (id: number, updatedTab: Partial<ITab>) => void;
   deleteTab: (tabId: number) => void;
+  moveTab: (tabId: number, targetTabId: number) => void;
 }
 
 const defaultAppData: AppData = {
@@ -94,6 +95,30 @@ export const useAppStore = create<AppStoreState>()((set) => {
         const newAppData: AppData = {
           tabs: newTabs,
           currentTabId: newCurrentTabId,
+        };
+        saveAppData(newAppData);
+        return newAppData;
+      });
+    },
+
+    moveTab: (tabId: number, targetTabId: number) => {
+      set((state) => {
+        if (tabId === targetTabId) return state;
+
+        const sourceIndex = state.tabs.findIndex((tab) => tab.id === tabId);
+        const targetIndex = state.tabs.findIndex(
+          (tab) => tab.id === targetTabId,
+        );
+
+        if (sourceIndex === -1 || targetIndex === -1) return state;
+
+        const newTabs = [...state.tabs];
+        const [movedTab] = newTabs.splice(sourceIndex, 1);
+        newTabs.splice(targetIndex, 0, movedTab);
+
+        const newAppData: AppData = {
+          tabs: newTabs,
+          currentTabId: state.currentTabId,
         };
         saveAppData(newAppData);
         return newAppData;

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -7,8 +7,8 @@ interface AppStoreState extends AppData {
   setCurrentTabId: (id: number) => void;
   createTab: () => number;
   updateTab: (id: number, updatedTab: Partial<ITab>) => void;
+  setTabs: (tabs: ITab[]) => void;
   deleteTab: (tabId: number) => void;
-  moveTab: (tabId: number, targetTabId: number) => void;
 }
 
 const defaultAppData: AppData = {
@@ -81,6 +81,17 @@ export const useAppStore = create<AppStoreState>()((set) => {
       });
     },
 
+    setTabs: (tabs: ITab[]) => {
+      set((state) => {
+        const newAppData: AppData = {
+          tabs,
+          currentTabId: state.currentTabId,
+        };
+        saveAppData(newAppData);
+        return newAppData;
+      });
+    },
+
     deleteTab: (tabId: number) => {
       set((state) => {
         if (state.tabs.length === 1) return state;
@@ -95,30 +106,6 @@ export const useAppStore = create<AppStoreState>()((set) => {
         const newAppData: AppData = {
           tabs: newTabs,
           currentTabId: newCurrentTabId,
-        };
-        saveAppData(newAppData);
-        return newAppData;
-      });
-    },
-
-    moveTab: (tabId: number, targetTabId: number) => {
-      set((state) => {
-        if (tabId === targetTabId) return state;
-
-        const sourceIndex = state.tabs.findIndex((tab) => tab.id === tabId);
-        const targetIndex = state.tabs.findIndex(
-          (tab) => tab.id === targetTabId,
-        );
-
-        if (sourceIndex === -1 || targetIndex === -1) return state;
-
-        const newTabs = [...state.tabs];
-        const [movedTab] = newTabs.splice(sourceIndex, 1);
-        newTabs.splice(targetIndex, 0, movedTab);
-
-        const newAppData: AppData = {
-          tabs: newTabs,
-          currentTabId: state.currentTabId,
         };
         saveAppData(newAppData);
         return newAppData;


### PR DESCRIPTION
This PR does the following:
- Makes all tabs draggable, this means that by holding on a tab and moving it across the tab bar the user can reorder them for convenience. 
- Changes min-width to 80px so there is enough space in the tab to fit the trash icon and allows it to stick to the same size instead of growing and shrinking when toggled active and inactive, respectfully (when using default names). 
- A small margin is added between the tab bar and the plus icon, so that they aren't glued together.
